### PR TITLE
Fix: Correct caching bug in Home Assistant tool

### DIFF
--- a/home_assistant_tool.py
+++ b/home_assistant_tool.py
@@ -143,6 +143,7 @@ class Tools:
         except requests.exceptions.RequestException as e:
             self.logger.error(f"Error fetching entities from Home Assistant: {e}")
             self.entities_cache = None # Invalidate cache on error
+            self.entities_last_fetched = None
             return []
 
     def _resolve_entity_id(self, device_name: str) -> Optional[str]:


### PR DESCRIPTION
This commit fixes a bug in the `_get_all_entities` method where the `entities_last_fetched` timestamp was not being cleared when the cache was invalidated due to an API error. This caused the tool to wait for up to 60 seconds before retrying to fetch data from the Home Assistant API.

The fix adds `self.entities_last_fetched = None` to the `except` block, ensuring that the timestamp is cleared along with the cache.